### PR TITLE
chore: Making matplotlib an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ requires-python = ">=3.10"
 
 dependencies = [
     "h5py>=3.12.1",
-    "matplotlib>=3.9.2",
     "scikit-learn>=1.6.1",
     "umap-learn>=0.5.7",
     "pacmap>=0.8.0",
@@ -23,6 +22,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+scripts = [
+    "matplotlib>=3.9.2",
+]
+
 frontend = [
     "gunicorn>=23.0.0",
     "python-dotenv>=1.0.1",
@@ -86,11 +89,11 @@ line-length = 88
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
+    "E", # pycodestyle errors
+    "W", # pycodestyle warnings
+    "F", # pyflakes
+    "I", # isort
+    "B", # flake8-bugbear
     "C4", # flake8-comprehensions
     "UP", # pyupgrade
     "ARG001", # unused-function-args
@@ -98,9 +101,9 @@ select = [
     "F841", # unused-variable
 ]
 ignore = [
-    "E501",  # line too long, handled by black
-    "B008",  # do not perform function calls in argument defaults
-    "C901",  # too complex
+    "E501", # line too long, handled by black
+    "B008", # do not perform function calls in argument defaults
+    "C901", # too complex
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Once applied, this PR will make matplotlib an optional dependency, as it is not used in the core library, but only by some supplementary scripts. This makes it easier to use ProtSpace in other environments. For that, I created a new optional dependency category "scripts"