### PR TITLE
Replace unipressed with direct UniProt REST API calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ Located in `notebooks/`:
 
 ## Dependencies
 
-**Core:** h5py, scikit-learn, umap-learn, pacmap (includes annoy), numpy, pandas, pyarrow, tqdm, requests, pymmseqs, unipressed, biocentral-api, typer, rich
+**Core:** h5py, scikit-learn, umap-learn, pacmap (includes annoy), numpy, pandas, pyarrow, tqdm, requests, pymmseqs, biocentral-api, typer, rich
 
 **Frontend (optional):** dash, plotly, dash-bootstrap-components, dash-molstar, gunicorn
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -46,7 +46,7 @@ With `--keep-tmp`, only API-fetched annotations are cached; the CSV is always re
 
 ## UniProt Annotations
 
-14 annotations retrieved from the [UniProt REST API](https://rest.uniprot.org/) via `unipressed` (batch size: 100):
+14 annotations retrieved from the [UniProt REST API](https://rest.uniprot.org/) (batch size: 100):
 
 | Name                      | Description                          | Example                                                        |
 | ------------------------- | ------------------------------------ | -------------------------------------------------------------- |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "tqdm>=4.67.1",
     "pymmseqs>=1.0.4",
     "pyarrow>=20.0.0",
-    "unipressed>=1.4.0",
     "biocentral-api>=1.1.2",
     "requests>=2.32.4",
     "typer>=0.24.1",

--- a/src/protspace/data/annotations/retrievers/http_utils.py
+++ b/src/protspace/data/annotations/retrievers/http_utils.py
@@ -1,0 +1,39 @@
+"""Shared HTTP utilities for UniProt-style REST API calls."""
+
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+API_TIMEOUT = 30
+
+
+def paginated_get(
+    url: str,
+    params: dict | None = None,
+    timeout: int = API_TIMEOUT,
+    result_key: str = "results",
+) -> list[dict]:
+    """Fetch all pages from a UniProt-style REST API endpoint.
+
+    Follows Link headers with rel="next" for automatic pagination.
+    Returns the concatenated contents of the ``result_key`` array
+    across all pages.
+    """
+    results = []
+
+    while url:
+        resp = requests.get(url, params=params, timeout=timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        results.extend(data.get(result_key, []))
+
+        # Follow Link header for next page
+        link = resp.headers.get("Link", "")
+        url = None
+        params = None  # next-page URL already contains all params
+        if 'rel="next"' in link:
+            url = link.split(";")[0].strip(" <>")
+
+    return results

--- a/src/protspace/data/annotations/retrievers/taxonomy_retriever.py
+++ b/src/protspace/data/annotations/retrievers/taxonomy_retriever.py
@@ -1,15 +1,14 @@
 import logging
 from typing import Any
 
-import requests
 from tqdm import tqdm
 
 from protspace.data.annotations.retrievers.base_retriever import BaseAnnotationRetriever
+from protspace.data.annotations.retrievers.http_utils import paginated_get
 
 logger = logging.getLogger(__name__)
 
 TAXONOMY_API_URL = "https://rest.uniprot.org/taxonomy/search"
-_API_TIMEOUT = 30
 _BATCH_SIZE = 100  # Max taxon IDs per request (URL length safety)
 
 # Taxonomy annotations
@@ -78,29 +77,17 @@ class TaxonomyRetriever(BaseAnnotationRetriever):
         query = " OR ".join(f"id:{tid}" for tid in taxon_ids)
 
         try:
-            url = TAXONOMY_API_URL
-            params = {"query": query, "format": "json", "size": "500"}
-
-            while url:
-                resp = requests.get(url, params=params, timeout=_API_TIMEOUT)
-                resp.raise_for_status()
-                data = resp.json()
-
-                for entry in data.get("results", []):
-                    taxon_id = entry.get("taxonId")
-                    if taxon_id is not None:
-                        result[taxon_id] = self._extract_taxonomy(entry)
-
-                # Pagination: follow Link header if present
-                link = resp.headers.get("Link", "")
-                url = None
-                params = None
-                if 'rel="next"' in link:
-                    url = link.split(";")[0].strip(" <>")
+            entries = paginated_get(
+                TAXONOMY_API_URL,
+                params={"query": query, "format": "json", "size": "500"},
+            )
+            for entry in entries:
+                taxon_id = entry.get("taxonId")
+                if taxon_id is not None:
+                    result[taxon_id] = self._extract_taxonomy(entry)
 
         except Exception as e:
             logger.error(f"Failed to fetch taxonomy batch: {e}")
-            # Return empty annotations for all IDs in this batch
             for tid in taxon_ids:
                 if tid not in result:
                     result[tid] = dict.fromkeys(self.annotations, "")

--- a/src/protspace/data/annotations/retrievers/uniprot_retriever.py
+++ b/src/protspace/data/annotations/retrievers/uniprot_retriever.py
@@ -11,6 +11,7 @@ import requests
 from tqdm import tqdm
 
 from protspace.data.annotations.retrievers.base_retriever import BaseAnnotationRetriever
+from protspace.data.annotations.retrievers.http_utils import API_TIMEOUT, paginated_get
 from protspace.data.parsers.uniprot_parser import UniProtEntry
 
 logger = logging.getLogger(__name__)
@@ -40,10 +41,7 @@ UNIPROT_ANNOTATIONS = [
 ProteinAnnotations = namedtuple("ProteinAnnotations", ["identifier", "annotations"])
 
 
-_API_TIMEOUT = 30  # seconds per HTTP request
-
-
-def _fetch_one_with_timeout(accession: str, timeout: int = _API_TIMEOUT) -> dict:
+def _fetch_one_with_timeout(accession: str, timeout: int = API_TIMEOUT) -> dict:
     """Fetch a single UniProt entry by accession with timeout protection."""
     url = f"https://rest.uniprot.org/uniprotkb/{accession}.json"
     resp = requests.get(url, timeout=timeout)
@@ -52,15 +50,9 @@ def _fetch_one_with_timeout(accession: str, timeout: int = _API_TIMEOUT) -> dict
 
 
 def _fetch_uniparc_sequence(
-    uniparc_id: str, timeout: int = _API_TIMEOUT
+    uniparc_id: str, timeout: int = API_TIMEOUT
 ) -> tuple[str, int]:
-    """Fetch sequence and length from UniParc.
-
-    Deleted UniProt entries still have their sequence archived in UniParc.
-
-    Returns:
-        Tuple of (sequence_string, length) or ("", 0) on failure.
-    """
+    """Fetch sequence and length from UniParc for deleted entries."""
     url = f"https://rest.uniprot.org/uniparc/{uniparc_id}.json"
     try:
         resp = requests.get(url, timeout=timeout)
@@ -75,48 +67,20 @@ def _fetch_uniparc_sequence(
         return "", 0
 
 
-def _fetch_many_accessions(
-    accessions: list[str], timeout: int = _API_TIMEOUT
-) -> list[dict]:
-    """Fetch multiple UniProt entries by accession via the REST API."""
-    results = []
-    url = "https://rest.uniprot.org/uniprotkb/accessions"
-    params = {"accessions": ",".join(accessions)}
-
-    while url:
-        resp = requests.get(url, params=params, timeout=timeout)
-        resp.raise_for_status()
-        data = resp.json()
-        results.extend(data.get("results", []))
-
-        link = resp.headers.get("Link", "")
-        url = None
-        params = None
-        if 'rel="next"' in link:
-            url = link.split(";")[0].strip(" <>")
-
-    return results
+def _fetch_many_accessions(accessions: list[str]) -> list[dict]:
+    """Fetch multiple UniProt entries by accession."""
+    return paginated_get(
+        "https://rest.uniprot.org/uniprotkb/accessions",
+        params={"accessions": ",".join(accessions)},
+    )
 
 
-def _search_sec_acc(accession: str, timeout: int = _API_TIMEOUT) -> list[dict]:
+def _search_sec_acc(accession: str) -> list[dict]:
     """Search UniProt by secondary accession (fallback for inactive entries)."""
-    records = []
-    url = "https://rest.uniprot.org/uniprotkb/search"
-    params = {"query": f"sec_acc:{accession}", "format": "json", "size": "500"}
-
-    while url:
-        resp = requests.get(url, params=params, timeout=timeout)
-        resp.raise_for_status()
-        data = resp.json()
-        records.extend(data.get("results", []))
-
-        link = resp.headers.get("Link", "")
-        url = None
-        params = None
-        if 'rel="next"' in link:
-            url = link.split(";")[0].strip(" <>")
-
-    return records
+    return paginated_get(
+        "https://rest.uniprot.org/uniprotkb/search",
+        params={"query": f"sec_acc:{accession}", "format": "json", "size": "500"},
+    )
 
 
 class UniProtRetriever(BaseAnnotationRetriever):

--- a/src/protspace/data/annotations/retrievers/uniprot_retriever.py
+++ b/src/protspace/data/annotations/retrievers/uniprot_retriever.py
@@ -4,13 +4,11 @@ UniProt annotation retriever.
 This module fetches protein annotations from the UniProt API.
 """
 
-import json
 import logging
 from collections import namedtuple
 
 import requests
 from tqdm import tqdm
-from unipressed import UniprotkbClient
 
 from protspace.data.annotations.retrievers.base_retriever import BaseAnnotationRetriever
 from protspace.data.parsers.uniprot_parser import UniProtEntry
@@ -46,11 +44,7 @@ _API_TIMEOUT = 30  # seconds per HTTP request
 
 
 def _fetch_one_with_timeout(accession: str, timeout: int = _API_TIMEOUT) -> dict:
-    """Fetch a single UniProt entry with a timeout.
-
-    The unipressed library's fetch_one() uses requests.get without a timeout,
-    which can hang indefinitely. This wrapper adds timeout protection.
-    """
+    """Fetch a single UniProt entry by accession with timeout protection."""
     url = f"https://rest.uniprot.org/uniprotkb/{accession}.json"
     resp = requests.get(url, timeout=timeout)
     resp.raise_for_status()
@@ -79,6 +73,50 @@ def _fetch_uniparc_sequence(
     except Exception as e:
         logger.debug(f"Failed to fetch UniParc sequence {uniparc_id}: {e}")
         return "", 0
+
+
+def _fetch_many_accessions(
+    accessions: list[str], timeout: int = _API_TIMEOUT
+) -> list[dict]:
+    """Fetch multiple UniProt entries by accession via the REST API."""
+    results = []
+    url = "https://rest.uniprot.org/uniprotkb/accessions"
+    params = {"accessions": ",".join(accessions)}
+
+    while url:
+        resp = requests.get(url, params=params, timeout=timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        results.extend(data.get("results", []))
+
+        link = resp.headers.get("Link", "")
+        url = None
+        params = None
+        if 'rel="next"' in link:
+            url = link.split(";")[0].strip(" <>")
+
+    return results
+
+
+def _search_sec_acc(accession: str, timeout: int = _API_TIMEOUT) -> list[dict]:
+    """Search UniProt by secondary accession (fallback for inactive entries)."""
+    records = []
+    url = "https://rest.uniprot.org/uniprotkb/search"
+    params = {"query": f"sec_acc:{accession}", "format": "json", "size": "500"}
+
+    while url:
+        resp = requests.get(url, params=params, timeout=timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        records.extend(data.get("results", []))
+
+        link = resp.headers.get("Link", "")
+        url = None
+        params = None
+        if 'rel="next"' in link:
+            url = link.split(";")[0].strip(" <>")
+
+    return records
 
 
 class UniProtRetriever(BaseAnnotationRetriever):
@@ -207,15 +245,7 @@ class UniProtRetriever(BaseAnnotationRetriever):
             except Exception:
                 # fetch_one failed — fall back to sec_acc: search
                 try:
-                    records = []
-                    for page in UniprotkbClient.search(
-                        query=f"sec_acc:{accession}", format="json"
-                    ).each_page():
-                        content = page.read() if hasattr(page, "read") else page
-                        parsed = (
-                            json.loads(content) if isinstance(content, str) else content
-                        )
-                        records.extend(parsed.get("results", []))
+                    records = _search_sec_acc(accession)
                     if records:
                         entry = UniProtEntry(records[0])
                         annotations_dict = self._extract_annotations(entry)
@@ -277,8 +307,7 @@ class UniProtRetriever(BaseAnnotationRetriever):
                 batch = self.headers[i : i + batch_size]
 
                 try:
-                    # Fetch records using unipressed
-                    records = UniprotkbClient.fetch_many(batch)
+                    records = _fetch_many_accessions(batch)
 
                     # Parse each record and track returned identifiers
                     returned_ids = set()

--- a/src/protspace/data/parsers/uniprot_parser.py
+++ b/src/protspace/data/parsers/uniprot_parser.py
@@ -50,7 +50,7 @@ xref_pdb                 - PDB cross-references (list)
 from typing import Any
 
 import pandas as pd
-from unipressed import UniprotkbClient
+import requests
 
 # ECO evidence code mapping (ECO ID → short human-readable code)
 ECO_TO_SHORT: dict[str, str] = {
@@ -586,9 +586,21 @@ def fetch_uniprot_data(
                 f"Invalid properties: {invalid}. Available: {AVAILABLE_PROPERTIES}"
             )
 
-    # Fetch records
-    records = UniprotkbClient.fetch_many(accessions)
-    entries = [UniProtEntry(record) for record in records]
+    # Fetch records via UniProt REST API
+    results = []
+    url = "https://rest.uniprot.org/uniprotkb/accessions"
+    params = {"accessions": ",".join(accessions)}
+    while url:
+        resp = requests.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        results.extend(data.get("results", []))
+        link = resp.headers.get("Link", "")
+        url = None
+        params = None
+        if 'rel="next"' in link:
+            url = link.split(";")[0].strip(" <>")
+    entries = [UniProtEntry(record) for record in results]
 
     # Extract properties
     data = []

--- a/src/protspace/data/parsers/uniprot_parser.py
+++ b/src/protspace/data/parsers/uniprot_parser.py
@@ -50,7 +50,8 @@ xref_pdb                 - PDB cross-references (list)
 from typing import Any
 
 import pandas as pd
-import requests
+
+from protspace.data.annotations.retrievers.http_utils import paginated_get
 
 # ECO evidence code mapping (ECO ID → short human-readable code)
 ECO_TO_SHORT: dict[str, str] = {
@@ -587,19 +588,10 @@ def fetch_uniprot_data(
             )
 
     # Fetch records via UniProt REST API
-    results = []
-    url = "https://rest.uniprot.org/uniprotkb/accessions"
-    params = {"accessions": ",".join(accessions)}
-    while url:
-        resp = requests.get(url, params=params, timeout=30)
-        resp.raise_for_status()
-        data = resp.json()
-        results.extend(data.get("results", []))
-        link = resp.headers.get("Link", "")
-        url = None
-        params = None
-        if 'rel="next"' in link:
-            url = link.split(";")[0].strip(" <>")
+    results = paginated_get(
+        "https://rest.uniprot.org/uniprotkb/accessions",
+        params={"accessions": ",".join(accessions)},
+    )
     entries = [UniProtEntry(record) for record in results]
 
     # Extract properties

--- a/tests/test_taxonomy_annotation_retriever.py
+++ b/tests/test_taxonomy_annotation_retriever.py
@@ -187,7 +187,7 @@ class TestTaxonomyConstants:
 class TestTaxonomyRetrieverMocked:
     """Unit tests with mocked UniProt Taxonomy API."""
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_bacteria_taxonomy(self, mock_get):
         """Test bacterial taxonomy (E. coli K-12)."""
         mock_get.return_value = _make_api_response(
@@ -215,7 +215,7 @@ class TestTaxonomyRetrieverMocked:
         assert annotations["genus"] == "Escherichia"
         assert annotations["species"] == "Escherichia coli"
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_human_species_from_own_rank(self, mock_get):
         """Test that species-rank taxon IDs get species from entry's own name."""
         mock_get.return_value = _make_api_response(
@@ -235,7 +235,7 @@ class TestTaxonomyRetrieverMocked:
         assert annotations["genus"] == "Homo"
         assert annotations["species"] == "Homo sapiens"
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_virus_realm_as_domain(self, mock_get):
         """Test viral taxonomy — realm used as domain fallback."""
         mock_get.return_value = _make_api_response(
@@ -260,7 +260,7 @@ class TestTaxonomyRetrieverMocked:
         assert annotations["kingdom"] == "Orthornavirae"
         assert annotations["family"] == "Coronaviridae"
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_batch_retrieval(self, mock_get):
         """Test batch retrieval of multiple organisms in one call."""
         mock_get.return_value = _make_api_response(
@@ -282,7 +282,7 @@ class TestTaxonomyRetrieverMocked:
         assert result[9606]["annotations"]["domain"] == "Eukaryota"
         assert result[2697049]["annotations"]["domain"] == "Riboviria"
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_partial_annotations(self, mock_get):
         """Test requesting only a subset of annotations."""
         mock_get.return_value = _make_api_response(
@@ -302,7 +302,7 @@ class TestTaxonomyRetrieverMocked:
         assert annotations["genus"] == "Homo"
         assert annotations["species"] == "Homo sapiens"
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_invalid_taxon_returns_empty(self, mock_get):
         """Test graceful handling of IDs not found in API response."""
         mock_get.return_value = _make_api_response([])  # No results
@@ -316,7 +316,7 @@ class TestTaxonomyRetrieverMocked:
         assert annotations["genus"] == ""
         assert annotations["species"] == ""
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_api_error_returns_empty(self, mock_get):
         """Test graceful handling of API errors."""
         mock_get.side_effect = Exception("Connection failed")
@@ -330,7 +330,7 @@ class TestTaxonomyRetrieverMocked:
         assert annotations["domain"] == ""
         assert annotations["genus"] == ""
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_missing_ranks_return_empty_strings(self, mock_get):
         """Test that missing taxonomy ranks return empty strings."""
         sparse_lineage = [
@@ -372,7 +372,7 @@ class TestTaxonomyRetrieverMocked:
         assert annotations["order"] == ""
         assert annotations["family"] == ""
 
-    @patch("protspace.data.annotations.retrievers.taxonomy_retriever.requests.get")
+    @patch("protspace.data.annotations.retrievers.http_utils.requests.get")
     def test_batch_chunking(self, mock_get):
         """Test that large ID lists are split into batches."""
         # Create 150 IDs to force 2 batches (batch size = 100)

--- a/tests/test_uniprot_annotation_retriever.py
+++ b/tests/test_uniprot_annotation_retriever.py
@@ -1,6 +1,4 @@
-import io
-import json
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from src.protspace.data.annotations.retrievers.uniprot_retriever import (
     UNIPROT_ANNOTATIONS,
@@ -10,6 +8,21 @@ from src.protspace.data.annotations.retrievers.uniprot_retriever import (
 
 # Alias for test compatibility
 UniProtAnnotationRetriever = UniProtRetriever
+
+_FETCH_ONE_PATCH = (
+    "src.protspace.data.annotations.retrievers"
+    ".uniprot_retriever._fetch_one_with_timeout"
+)
+_UNIPARC_PATCH = (
+    "src.protspace.data.annotations.retrievers"
+    ".uniprot_retriever._fetch_uniparc_sequence"
+)
+_FETCH_MANY_PATCH = (
+    "src.protspace.data.annotations.retrievers.uniprot_retriever._fetch_many_accessions"
+)
+_SEARCH_SEC_ACC_PATCH = (
+    "src.protspace.data.annotations.retrievers.uniprot_retriever._search_sec_acc"
+)
 
 
 class TestUniProtAnnotationRetrieverInit:
@@ -96,10 +109,8 @@ class TestManageHeaders:
 class TestFetchAnnotations:
     """Test the fetch_annotations method."""
 
-    @patch(
-        "src.protspace.data.annotations.retrievers.uniprot_retriever.UniprotkbClient"
-    )
-    def test_fetch_annotations_success(self, mock_client_class):
+    @patch(_FETCH_MANY_PATCH)
+    def test_fetch_annotations_success(self, mock_fetch_many):
         """Test successful annotation fetching with new unipressed implementation."""
         # Mock API response with minimal required fields
         mock_records = [
@@ -141,7 +152,7 @@ class TestFetchAnnotations:
             },
         ]
 
-        mock_client_class.fetch_many.return_value = mock_records
+        mock_fetch_many.return_value = mock_records
 
         # Create retriever and test
         headers = ["P01308", "P01315"]
@@ -163,17 +174,15 @@ class TestFetchAnnotations:
         assert result[1].annotations["annotation_score"] == "4.0"
 
         # Verify API call
-        mock_client_class.fetch_many.assert_called_once_with(["P01308", "P01315"])
+        mock_fetch_many.assert_called_once_with(["P01308", "P01315"])
 
-    @patch(
-        "src.protspace.data.annotations.retrievers.uniprot_retriever.UniprotkbClient"
-    )
-    def test_fetch_annotations_batching_logic(self, mock_client_class):
+    @patch(_FETCH_MANY_PATCH)
+    def test_fetch_annotations_batching_logic(self, mock_fetch_many):
         """Test annotation fetching with batching behavior."""
         # Create mock records for batching test
         headers = [f"P{i:05d}" for i in range(150)]  # More than batch size (100)
 
-        def mock_fetch_many(batch):
+        def mock_fetch_many_fn(batch):
             """Mock fetch_many to return appropriate records for batch."""
             return [
                 {
@@ -197,7 +206,7 @@ class TestFetchAnnotations:
                 for i, acc in enumerate(batch)
             ]
 
-        mock_client_class.fetch_many.side_effect = mock_fetch_many
+        mock_fetch_many.side_effect = mock_fetch_many_fn
 
         # Create retriever and test
         annotations = ["entry", "length"]
@@ -208,15 +217,13 @@ class TestFetchAnnotations:
         # Verify results
         assert len(result) == 150
         # Verify API was called multiple times for batching
-        assert mock_client_class.fetch_many.call_count == 2  # 100 + 50
+        assert mock_fetch_many.call_count == 2  # 100 + 50
 
-    @patch(
-        "src.protspace.data.annotations.retrievers.uniprot_retriever.UniprotkbClient"
-    )
-    def test_fetch_annotations_handles_errors(self, mock_client_class):
+    @patch(_FETCH_MANY_PATCH)
+    def test_fetch_annotations_handles_errors(self, mock_fetch_many):
         """Test handling of API errors."""
         # Mock API to raise an exception
-        mock_client_class.fetch_many.side_effect = Exception("API Error")
+        mock_fetch_many.side_effect = Exception("API Error")
 
         # Create retriever and test
         headers = ["P01308"]
@@ -231,10 +238,8 @@ class TestFetchAnnotations:
         # All annotations should be empty strings due to error
         assert all(v == "" for v in result[0].annotations.values())
 
-    @patch(
-        "src.protspace.data.annotations.retrievers.uniprot_retriever.UniprotkbClient"
-    )
-    def test_fetch_annotations_stores_uniprot_annotations(self, mock_client_class):
+    @patch(_FETCH_MANY_PATCH)
+    def test_fetch_annotations_stores_uniprot_annotations(self, mock_fetch_many):
         """Test that fetch_annotations stores UNIPROT_ANNOTATIONS including organism_id."""
         mock_records = [
             {
@@ -260,7 +265,7 @@ class TestFetchAnnotations:
             }
         ]
 
-        mock_client_class.fetch_many.return_value = mock_records
+        mock_fetch_many.return_value = mock_records
 
         # Request annotations (actual storage is UNIPROT_ANNOTATIONS)
         headers = ["P01308"]
@@ -286,10 +291,8 @@ class TestFetchAnnotations:
             result[0].annotations["gene_name"] == "INS"
         )  # Gene name from genes[0].geneName
 
-    @patch(
-        "src.protspace.data.annotations.retrievers.uniprot_retriever.UniprotkbClient"
-    )
-    def test_reviewed_field_parsing_swiss_prot_and_trembl(self, mock_client_class):
+    @patch(_FETCH_MANY_PATCH)
+    def test_reviewed_field_parsing_swiss_prot_and_trembl(self, mock_fetch_many):
         """End-to-end test: reviewed field correctly parsed for both Swiss-Prot and TrEMBL entries."""
         # Mock API responses with both reviewed (Swiss-Prot) and unreviewed (TrEMBL) entries
         mock_records = [
@@ -331,7 +334,7 @@ class TestFetchAnnotations:
             },
         ]
 
-        mock_client_class.fetch_many.return_value = mock_records
+        mock_fetch_many.return_value = mock_records
 
         # Create retriever and fetch
         headers = ["P01308", "Q12345"]
@@ -425,12 +428,6 @@ def _make_mock_record(
     }
 
 
-def _make_search_page(records):
-    """Build a TextIOWrapper mimicking unipressed search().each_page() output."""
-    content = json.dumps({"results": records})
-    return io.TextIOWrapper(io.BytesIO(content.encode("utf-8")), encoding="utf-8")
-
-
 class TestExtractAnnotations:
     """Test the _extract_annotations static method."""
 
@@ -471,19 +468,6 @@ class TestExtractAnnotations:
         assert result["organism_id"] == "9606"
         assert result["annotation_score"] == "3.0"
         assert result["reviewed"] == "Swiss-Prot"
-
-
-_FETCH_ONE_PATCH = (
-    "src.protspace.data.annotations.retrievers"
-    ".uniprot_retriever._fetch_one_with_timeout"
-)
-_UNIPARC_PATCH = (
-    "src.protspace.data.annotations.retrievers"
-    ".uniprot_retriever._fetch_uniparc_sequence"
-)
-_CLIENT_PATCH = (
-    "src.protspace.data.annotations.retrievers.uniprot_retriever.UniprotkbClient"
-)
 
 
 class TestResolveInactiveEntries:
@@ -617,19 +601,14 @@ class TestResolveInactiveEntries:
         assert res_count == 0
         assert del_count == 1
 
-    @patch(_CLIENT_PATCH)
+    @patch(_SEARCH_SEC_ACC_PATCH)
     @patch(_FETCH_ONE_PATCH)
-    def test_fetch_one_fails_falls_back_to_sec_acc(
-        self, mock_fetch_one, mock_client_class
-    ):
+    def test_fetch_one_fails_falls_back_to_sec_acc(self, mock_fetch_one, mock_search):
         """When fetch_one raises, falls back to sec_acc: search."""
         mock_fetch_one.side_effect = Exception("404 Not Found")
 
         replacement_record = _make_mock_record("Q076D1", protein_name="Crotastatin")
-        page = _make_search_page([replacement_record])
-        mock_search_result = Mock()
-        mock_search_result.each_page.return_value = iter([page])
-        mock_client_class.search.return_value = mock_search_result
+        mock_search.return_value = [replacement_record]
 
         retriever = UniProtRetriever(headers=[])
         resolved, res_count, del_count = retriever._resolve_inactive_entries(["C5H5D1"])
@@ -639,22 +618,14 @@ class TestResolveInactiveEntries:
         assert resolved[0].annotations["protein_name"] == "Crotastatin"
         assert res_count == 1
         assert del_count == 0
-        mock_client_class.search.assert_called_once_with(
-            query="sec_acc:C5H5D1", format="json"
-        )
+        mock_search.assert_called_once_with("C5H5D1")
 
-    @patch(_CLIENT_PATCH)
+    @patch(_SEARCH_SEC_ACC_PATCH)
     @patch(_FETCH_ONE_PATCH)
-    def test_fetch_one_fails_sec_acc_no_results(
-        self, mock_fetch_one, mock_client_class
-    ):
+    def test_fetch_one_fails_sec_acc_no_results(self, mock_fetch_one, mock_search):
         """When fetch_one fails and sec_acc returns nothing → empty annotations."""
         mock_fetch_one.side_effect = Exception("404 Not Found")
-
-        page = _make_search_page([])
-        mock_search_result = Mock()
-        mock_search_result.each_page.return_value = iter([page])
-        mock_client_class.search.return_value = mock_search_result
+        mock_search.return_value = []
 
         retriever = UniProtRetriever(headers=[])
         resolved, res_count, del_count = retriever._resolve_inactive_entries(["XXXXXX"])
@@ -665,12 +636,12 @@ class TestResolveInactiveEntries:
         assert res_count == 0
         assert del_count == 1
 
-    @patch(_CLIENT_PATCH)
+    @patch(_SEARCH_SEC_ACC_PATCH)
     @patch(_FETCH_ONE_PATCH)
-    def test_both_fetch_one_and_search_fail(self, mock_fetch_one, mock_client_class):
+    def test_both_fetch_one_and_search_fail(self, mock_fetch_one, mock_search):
         """When both fetch_one and search fail → empty annotations."""
         mock_fetch_one.side_effect = Exception("404")
-        mock_client_class.search.side_effect = Exception("Network error")
+        mock_search.side_effect = Exception("Network error")
 
         retriever = UniProtRetriever(headers=[])
         resolved, res_count, del_count = retriever._resolve_inactive_entries(["BROKEN"])
@@ -723,11 +694,11 @@ class TestFetchAnnotationsWithMissingEntries:
     """Test that fetch_annotations detects and resolves missing entries."""
 
     @patch(_FETCH_ONE_PATCH)
-    @patch(_CLIENT_PATCH)
-    def test_missing_entries_are_resolved(self, mock_client_class, mock_fetch_one):
+    @patch(_FETCH_MANY_PATCH)
+    def test_missing_entries_are_resolved(self, mock_fetch_many, mock_fetch_one):
         """When fetch_many drops an entry, it gets resolved via fetch_one."""
         # fetch_many returns only P01308, dropping C5H5D1
-        mock_client_class.fetch_many.return_value = [
+        mock_fetch_many.return_value = [
             _make_mock_record("P01308", protein_name="Insulin"),
         ]
 
@@ -746,12 +717,10 @@ class TestFetchAnnotationsWithMissingEntries:
         assert resolved.annotations["protein_name"] == "Crotastatin"
 
     @patch(_FETCH_ONE_PATCH)
-    @patch(_CLIENT_PATCH)
-    def test_no_missing_entries_skips_resolution(
-        self, mock_client_class, mock_fetch_one
-    ):
+    @patch(_FETCH_MANY_PATCH)
+    def test_no_missing_entries_skips_resolution(self, mock_fetch_many, mock_fetch_one):
         """When all entries are returned, _resolve_inactive_entries is not called."""
-        mock_client_class.fetch_many.return_value = [
+        mock_fetch_many.return_value = [
             _make_mock_record("P01308"),
             _make_mock_record("P01315"),
         ]
@@ -761,4 +730,3 @@ class TestFetchAnnotationsWithMissingEntries:
 
         assert len(result) == 2
         mock_fetch_one.assert_not_called()
-        mock_client_class.search.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -2741,7 +2741,6 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
     { name = "umap-learn" },
-    { name = "unipressed" },
 ]
 
 [package.optional-dependencies]
@@ -2809,7 +2808,6 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "typer", specifier = ">=0.24.1" },
     { name = "umap-learn", specifier = ">=0.5.10" },
-    { name = "unipressed", specifier = ">=1.4.0" },
 ]
 provides-extras = ["frontend"]
 
@@ -4128,20 +4126,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/9a/a1e4a257a9aa979dac4f6d5781dac929cbb0949959e2003ed82657d10b0f/umap_learn-0.5.11.tar.gz", hash = "sha256:31566ffd495fbf05d7ab3efcba703861c0f5e6fc6998a838d0e2becdd00e54f5", size = 96409, upload-time = "2026-01-12T20:44:47.553Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/d2/fcf7192dd1cd8c090b6cfd53fa223c4fb2887a17c47e06bc356d44f40dfb/umap_learn-0.5.11-py3-none-any.whl", hash = "sha256:cb17adbde9d544ba79481b3ab4d81ac222e940f3d9219307bea6044f869af3cc", size = 90890, upload-time = "2026-01-12T20:44:46.511Z" },
-]
-
-[[package]]
-name = "unipressed"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/f3/1bff788016e59c20228e0afd5336766723a2ad07dcc2de63de2fce8943af/unipressed-1.4.0.tar.gz", hash = "sha256:a590f4b8f41b4daf5485400b6149449face7ca91e3e93a113dacefbfdc684887", size = 27337, upload-time = "2024-08-16T12:05:21.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/f3/9e4144e6fdfcc9fb8de255564e9773dc3ee9499a27ca706fda8b495fbb0f/unipressed-1.4.0-py3-none-any.whl", hash = "sha256:f3c53280668846b3164eae066a575b28399d1606d124f6cce5ac0bf405cf24e1", size = 35784, upload-time = "2024-08-16T12:05:19.904Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace `unipressed` (community UniProt API wrapper) with direct `requests`-based calls to `rest.uniprot.org`
- Add `_fetch_many_accessions()` and `_search_sec_acc()` helpers with Link-header pagination (same pattern as taxonomy retriever)
- Simplify sec_acc search fallback from 8 lines of page-parsing to a single function call
- Remove `unipressed` dependency

Closes #32

## Test plan

- [x] `uv run pytest tests/test_uniprot_annotation_retriever.py -v` — 29 tests pass
- [x] `uv run pytest tests/ -m "not slow"` — 413 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)